### PR TITLE
Use hostname as device name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Then follow the steps from the previous section.
 
 # Usage
 Run `./all.sh` to initiate lazycast receiver. Wait until the "The display is ready" message.
-The name of your device will also be displayed on the screen.
-Then, search for the wireless display displayed on the Pi of the source device you want to cast. Use the PIN number under the "The display is ready" message if the device is asking for a WPS PIN number.  
+The name of your device will also be displayed on the pi.
+Then, search for the wireless display on the source device you want to cast. Use the PIN number under the "The display is ready" message if the device is asking for a WPS PIN number.  
 If backchannel control is supported by the source, keyboard and mouse input on Pi are redirected to the source as remote controls.  
 It is recommended to initiate the termination of the receiver on the source side. These user controls are often near the pairing controls on the source device. You can utilize the backchannel feature to remotely control the source device in order to close lazycast.  
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Then follow the steps from the previous section.
 
 
 # Usage
-Run `./all.sh` to initiate lazycast receiver. Wait until the "The display is ready" message.  
-Then, search for the wireless display named "lazycast" on the source device you want to cast. Use the PIN number under the "The display is ready" message if the device is asking for a WPS PIN number.  
+Run `./all.sh` to initiate lazycast receiver. Wait until the "The display is ready" message.
+The name of your device will also be displayed on the screen.
+Then, search for the wireless display displayed on the Pi of the source device you want to cast. Use the PIN number under the "The display is ready" message if the device is asking for a WPS PIN number.  
 If backchannel control is supported by the source, keyboard and mouse input on Pi are redirected to the source as remote controls.  
 It is recommended to initiate the termination of the receiver on the source side. These user controls are often near the pairing controls on the source device. You can utilize the backchannel feature to remotely control the source device in order to close lazycast.  
 

--- a/all.sh
+++ b/all.sh
@@ -17,7 +17,7 @@ then
 
 else
 	sudo wpa_cli p2p_find type=progessive
-	sudo wpa_cli set device_name lazycast
+	sudo wpa_cli set device_name "$(uname -n)"
 	sudo wpa_cli set device_type 7-0050F204-1
 	sudo wpa_cli set p2p_go_ht40 1
 	sudo wpa_cli wfd_subelem_set 0 00060151022a012c

--- a/all.sh
+++ b/all.sh
@@ -63,7 +63,7 @@ sudo udhcpd ./udhcpd.conf
 echo "The display is ready"
 while :
 do
-	echo "Your device is called "$(uname -n)"."
+	echo "Your device is called: "$(uname -n)""
 	echo "PIN:"	
 	sudo wpa_cli -i$p2pinterface wps_pin any
 	echo ""

--- a/all.sh
+++ b/all.sh
@@ -42,7 +42,7 @@ else
 			ain="$(sudo wpa_cli interface)"
 			echo "$ain"
 		done
-		sleep 5
+		sleep 2
 		ain="$(sudo wpa_cli interface)"
                 echo "$ain"
 	done

--- a/all.sh
+++ b/all.sh
@@ -63,7 +63,7 @@ sudo udhcpd ./udhcpd.conf
 echo "The display is ready"
 while :
 do
-	echo "Your device is called "${uname -n}"."
+	echo "Your device is called "$(uname -n)"."
 	echo "PIN:"	
 	sudo wpa_cli -i$p2pinterface wps_pin any
 	echo ""

--- a/all.sh
+++ b/all.sh
@@ -63,6 +63,7 @@ sudo udhcpd ./udhcpd.conf
 echo "The display is ready"
 while :
 do
+	echo "Your device is called "${uname -n}"."
 	echo "PIN:"	
 	sudo wpa_cli -i$p2pinterface wps_pin any
 	echo ""


### PR DESCRIPTION
Use hostname as device name, useful when setting up multiple receivers.