### PR TITLE
Use "vcgencmd" instead of "tvservice" for power management

### DIFF
--- a/d2.py
+++ b/d2.py
@@ -141,7 +141,7 @@ def killall(control):
         os.system('pkill player.bin')
         os.system('pkill h264.bin')
         if display_power_management == True:
-                os.system('tvservice -o')
+                os.system('vcgencmd display_power 0')
         if control == True:
                 os.system('pkill control.bin')
                 os.system('pkill controlhidc.bin')
@@ -197,7 +197,7 @@ if (os.uname()[-1][:4] != "armv"):
 def launchplayer(player_select):
 	killall(False)
         if display_power_management == True:
-                os.system('tvservice -p')
+                os.system('vcgencmd display_power 1')
 	if player_select == 0:
 		os.system('vlc --fullscreen rtp://0.0.0.0:1028/wfd1.0/streamid=0 &')
 	elif player_select == 1:


### PR DESCRIPTION
* tvservice is causing blank screen for some users. (like for me on RPi 3B+)
* tvservice is not the best way to turn off and on the screen.
refer: https://raspberrypi.stackexchange.com/questions/52042/turning-tvservice-on-and-off-leaves-screen-blank