### PR TITLE
Revert "Make the .py scripts compatible with python3"

### DIFF
--- a/d2.py
+++ b/d2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 
 """
 	This software is part of lazycast, a simple wireless display receiver for Raspberry Pi
@@ -76,25 +76,25 @@ idrsock.bind(idrsock_address)
 addr, idrsockport = idrsock.getsockname()
 
 data = (sock.recv(1000))
-print("---M1--->\n" + data)
+print "---M1--->\n" + data
 s_data = 'RTSP/1.0 200 OK\r\nCSeq: 1\r\nPublic: org.wfa.wfd1.0, SET_PARAMETER, GET_PARAMETER\r\n\r\n'
-print("<--------\n" + s_data)
+print "<--------\n" + s_data
 sock.sendall(s_data)
 
 
 # M2
 s_data = 'OPTIONS * RTSP/1.0\r\nCSeq: 1\r\nRequire: org.wfa.wfd1.0\r\n\r\n'
-print("<---M2---\n" + s_data)
+print "<---M2---\n" + s_data
 sock.sendall(s_data)
 
 data = (sock.recv(1000))
-print("-------->\n" + data)
+print "-------->\n" + data
 m2data = data
 
 
 # M3
 data=(sock.recv(1000))
-print("---M3--->\n" + data)
+print "---M3--->\n" + data
 
 msg = 'wfd_client_rtp_ports: RTP/AVP/UDP;unicast 1028 0 mode=play\r\n'
 if player_select == 2:
@@ -129,7 +129,7 @@ if os.path.exists('edid.txt'):
 	edidlen = len(edidstr)
 
 if 'wfd_display_edid' in data and edidlen != 0:
-	msg = msg + 'wfd_display_edid: ' + '{:04X}'.format(edidlen/256 + 1) + ' ' + str(edidstr.encode('utf-8').hex())+'\r\n'
+	msg = msg + 'wfd_display_edid: ' + '{:04X}'.format(edidlen/256 + 1) + ' ' + str(edidstr.encode('hex'))+'\r\n'
 
 # if 'microsoft_latency_management_capability' in data:
 # 	msg = msg + 'microsoft-latency-management-capability: supported\r\n'
@@ -151,16 +151,16 @@ if 'intel_sink_device_URL' in data:
 
 
 m3resp ='RTSP/1.0 200 OK\r\nCSeq: 2\r\n'+'Content-Type: text/parameters\r\nContent-Length: '+str(len(msg))+'\r\n\r\n'+msg
-print("<--------\n" + m3resp)
+print "<--------\n" + m3resp
 sock.sendall(m3resp)
 
 
 # M4
 data=(sock.recv(1000))
-print("---M4--->\n" + data)
+print "---M4--->\n" + data
 
 s_data = 'RTSP/1.0 200 OK\r\nCSeq: 3\r\n\r\n'
-print("<--------\n" + s_data)
+print "<--------\n" + s_data
 sock.sendall(s_data)
 
 def uibcstart(sock, data):
@@ -174,7 +174,7 @@ def uibcstart(sock, data):
 			uibcport = uibcport[0]
 			uibcport = uibcport.split('=')
 			uibcport = uibcport[1]
-			print('uibcport:'+uibcport+"\n")
+			print 'uibcport:'+uibcport+"\n"
 			if 'none' not in uibcport and enable_mouse_keyboard == 1:
 				os.system('pkill control.bin')
 				os.system('pkill controlhidc.bin')
@@ -199,10 +199,10 @@ def killall(control):
 
 # M5
 data=(sock.recv(1000))
-print("---M5--->\n" + data)
+print "---M5--->\n" + data
 
 s_data = 'RTSP/1.0 200 OK\r\nCSeq: 4\r\n\r\n'
-print("<--------\n" + s_data)
+print "<--------\n" + s_data
 sock.sendall(s_data)
 
 
@@ -210,19 +210,19 @@ sock.sendall(s_data)
 m6req ='SETUP rtsp://'+sourceip+'/wfd1.0/streamid=0 RTSP/1.0\r\n'\
 +'CSeq: 5\r\n'\
 +'Transport: RTP/AVP/UDP;unicast;client_port=1028\r\n\r\n'
-print("<---M6---\n" + m6req)
+print "<---M6---\n" + m6req
 sock.sendall(m6req)
 
 data=(sock.recv(1000))
-print("-------->\n" + data)
+print "-------->\n" + data
 
 paralist=data.split(';')
-print(paralist)
+print paralist
 serverport=[x for x in paralist if 'server_port=' in x]
-print(serverport)
+print serverport
 serverport=serverport[-1]
 serverport=serverport[12:17]
-print(serverport)
+print serverport
 
 paralist=data.split( )
 position=paralist.index('Session:')+1
@@ -233,13 +233,13 @@ sessionid=paralist[position]
 m7req ='PLAY rtsp://'+sourceip+'/wfd1.0/streamid=0 RTSP/1.0\r\n'\
 +'CSeq: 6\r\n'\
 +'Session: '+str(sessionid)+'\r\n\r\n'
-print("<---M7---\n" + m7req)
+print "<---M7---\n" + m7req
 sock.sendall(m7req)
 
 data=(sock.recv(1000))
-print("-------->\n" + data)
+print "-------->\n" + data
 
-print("---- Negotiation successful ----")
+print "---- Negotiation successful ----"
 
 
 if not runonpi:
@@ -262,7 +262,7 @@ def launchplayer(player_select):
 		os.system('./player/player.bin '+str(idrsockport)+' '+str(sound_output_select)+' &')
 	elif player_select == 2:
 		sinkip = sock.getsockname()[0]
-		print(sinkip)
+		print sinkip
 		print('./h264/h264.bin '+str(idrsockport)+' '+str(sound_output_select)+' '+sinkip+' &')
 		os.system('./h264/h264.bin '+str(idrsockport)+' '+str(sound_output_select)+' '+sinkip+' &')
 	elif player_select == 3:
@@ -308,7 +308,7 @@ while True:
 				else:
 					sys.exit(1)
 			else:
-				print(datafromc)
+				print datafromc
 				elemfromc = datafromc.split(' ')				
 				if elemfromc[0] == 'recv':
 					killall(True)
@@ -323,13 +323,13 @@ while True:
 					+'CSeq: '+str(csnum)+'\r\n\r\n'\
 					+msg
 	
-					print(idrreq)
+					print idrreq
 					sock.sendall(idrreq)
 
 		else:
 			sys.exit(1)
 	else:
-		print(data)
+		print data
 		watchdog = 0
 		if len(data)==0 or 'wfd_trigger_method: TEARDOWN' in data:
 			killall(True)
@@ -338,9 +338,9 @@ while True:
 		elif 'wfd_video_formats' in data:
 			launchplayer(player_select)
 		messagelist=data.split('\r\n\r\n')
-		print(messagelist)
+		print messagelist
 		singlemessagelist=[x for x in messagelist if ('GET_PARAMETER' in x or 'SET_PARAMETER' in x )]
-		print(singlemessagelist)
+		print singlemessagelist
 		for singlemessage in singlemessagelist:
 			entrylist=singlemessage.split('\r')
 			for entry in entrylist:
@@ -348,7 +348,7 @@ while True:
 					cseq = entry
 
 			resp='RTSP/1.0 200 OK\r'+cseq+'\r\n\r\n';#cseq contains \n
-			print(resp)
+			print resp
 			sock.sendall(resp)
 		
 		uibcstart(sock,data)

--- a/mice.py
+++ b/mice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 """
 	This software is part of lazycast, a simple wireless display receiver for Raspberry Pi
 	Copyright (C) 2020 Hsun-Wei Cho
@@ -20,7 +20,7 @@
 import dbus
 import sys, os
 import time
-from gi.repository import GObject as gobject
+import gobject
 import threading
 import socket
 from dbus.mainloop.glib import DBusGMainLoop
@@ -58,25 +58,25 @@ if len(ipelems)>1 and ipstr == '':
 
 def groupStarted(properties):
 
-	print("groupStarted: " + str(properties))
+	print "groupStarted: " + str(properties)
 	g_obj = dbus.SystemBus().get_object('fi.w1.wpa_supplicant1',properties['group_object'])
 	res = g_obj.GetAll('fi.w1.wpa_supplicant1.Group', dbus_interface=dbus.PROPERTIES_IFACE, byte_arrays=True)
-	print("Group properties: " + str(res))
+	print "Group properties: " + str(res)
 	
-	hostnamehex = hostname.encode('utf-8').hex()
+	hostnamehex = hostname.encode('hex')
 	hostnamemessage = '2002'+'{:04X}'.format(len(hostname))+hostnamehex
 
 	ipmessage = ''
 	
 	if ipstr != '':
 		# The spec supportes multiple ip attributes. However, Windows will only try the first one
-		iphex = ipstr.encode('utf-8').hex()
+		iphex = ipstr.encode('hex')
 		ipmessage = '2005'+'{:04X}'.format(len(iphex)/2)+iphex
 
 	capandhostmessage = '0001372001000105' + hostnamemessage + ipmessage
 
 	innerarray = []
-	for c in bytes.fromhex(capandhostmessage).decode('utf-8'):
+	for c in capandhostmessage.decode('hex'):
 		innerarray.append(dbus.Byte(c))
 
 	g_obj.Set('fi.w1.wpa_supplicant1.Group', 'WPSVendorExtensions',  
@@ -84,7 +84,7 @@ def groupStarted(properties):
 
 	g_obj = dbus.SystemBus().get_object('fi.w1.wpa_supplicant1',properties['group_object'])
 	res = g_obj.GetAll('fi.w1.wpa_supplicant1.Group', dbus_interface=dbus.PROPERTIES_IFACE, byte_arrays=True)
-	print("Group properties: " + str(res))
+	print "Group properties: " + str(res)
 
 	event.set()
 	
@@ -161,7 +161,7 @@ class P2P_Group_Add (threading.Thread):
 
 		props = self.interface_object.GetAll(self.wpas_dbus_interfaces_p2pdevice,dbus_interface=dbus.PROPERTIES_IFACE)
 		print(props)
-		print('')	
+		print ''	
 
 		dbus.Interface(self.interface_object, dbus_interface=dbus.PROPERTIES_IFACE).Set(self.wpas_dbus_interfaces_p2pdevice, 'P2PDeviceConfig',dbus.Dictionary({ 'DeviceName' : hostname},signature='sv'))
 
@@ -171,7 +171,7 @@ class P2P_Group_Add (threading.Thread):
 
 		props = self.wpas_object.GetAll('fi.w1.wpa_supplicant1',dbus_interface=dbus.PROPERTIES_IFACE)
 		print(props)
-		print('')	
+		print ''	
 
 	def run(self):
 
@@ -180,8 +180,8 @@ class P2P_Group_Add (threading.Thread):
 			self.interfacep2pdevice.GroupAdd(groupadddict)
 		except:
 			print('Warning:\n  Could not preform group add')
-			print('If existing beacon does not function properly, run ./removep2p.sh first.')
-			print('Now running ./project.py')
+			print 'If existing beacon does not function properly, run ./removep2p.sh first.'
+			print 'Now running ./project.py'
 			event.set()
 
 		gobject.MainLoop().get_context().iteration(True)

--- a/project.py
+++ b/project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 """
 	This software is part of lazycast, a simple wireless display receiver for Raspberry Pi
 	Copyright (C) 2020 Hsun-Wei Cho
@@ -49,12 +49,12 @@ else:
 	uuidfile.close()
 
 hostname = socket.gethostname() 
-print('The hostname of this machine is: '+hostname)
+print 'The hostname of this machine is: '+hostname
 
-print(uuidstr)
+print uuidstr
 
 dnsstr = 'avahi-publish-service '+hostname+' _display._tcp 7250 container_id={'+uuidstr+'}'
-print(dnsstr)
+print dnsstr
 os.system(dnsstr+' &')
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -73,19 +73,19 @@ while True:
 	while True:
 		data = conn.recv(1024)
 		# print data
-		print(data.encode('utf-8').hex())
+		print data.encode('hex')
 
 		if data == '':
 			break
 
-		size = int(data[0:2].encode('utf-8').hex(),16)
-		version = data[2].encode('utf-8').hex()
-		command = data[3].encode('utf-8').hex()
+		size = int(data[0:2].encode('hex'),16)
+		version = data[2].encode('hex')
+		command = data[3].encode('hex')
 
 		print (size,version,command)
 		
 		messagetype = commands[command]
-		print(messagetype)
+		print messagetype
 
 		if messagetype == 'SOURCE_READY':
 			os.system('./d2.py '+sourceip+' &')
@@ -93,15 +93,15 @@ while True:
 
 		i = 4
 		while i<size:
-			tlvtypehex = data[i].encode('utf-8').hex()
-			valuelen = int(data[i+1:i+3].encode('utf-8').hex(),16)
+			tlvtypehex = data[i].encode('hex')
+			valuelen = int(data[i+1:i+3].encode('hex'),16)
 			value = data[i+3:i+3+valuelen]
 			i = i+3+valuelen
-			print(tlvtypehex,valuelen)
+			print (tlvtypehex,valuelen)
 			tlvtype = types[tlvtypehex]
-			print(tlvtype)
+			print tlvtype,
 			if tlvtype == 'FRIENDLY_NAME':
-				print(value)
+				print value
 
 
 		# conn.send(data)


### PR DESCRIPTION
Reverts homeworkc/lazycast#106

There are issues with Bullseye that go beyond python2 and python3 and the print syntax. (For example, the video hardware acceleration layer is completely changed.) While running lazycast on Bullseye is possible (using VLC or gstreamer), the latency is significantly higher than running on Buster or older distro.