### PR TITLE
Restart dhcpcd just after creating p2p interface

### DIFF
--- a/d2.py
+++ b/d2.py
@@ -446,7 +446,7 @@ print("---- Negotiation successful ----")
 fcntl.fcntl(sock, fcntl.F_SETFL, os.O_NONBLOCK)
 fcntl.fcntl(idrsock, fcntl.F_SETFL, os.O_NONBLOCK)
 
-
+negotiation_time = time.time()
 
 csnum = 102
 watchdog = 0
@@ -503,7 +503,7 @@ while True:
 			killall(True)
 			sleep(1)
 			break
-		elif 'wfd_video_formats' in data:
+		elif 'wfd_video_formats' in data and time.time() - negotiation_time > 5:
 			launchplayer(player_select)
 		messagelist=data.split('\r\n\r\n')
 		print(messagelist)

--- a/mice.sh
+++ b/mice.sh
@@ -12,6 +12,7 @@
 sudo systemctl stop dhcpcd
 sudo systemctl stop wpa_supplicant
 sudo wpa_supplicant -Dnl80211 -iwlan0 -u -c/etc/wpa_supplicant/wpa_supplicant.conf &
+sleep 1; sudo systemctl start dhcpcd
 
 LD_LIBRARY_PATH=/opt/vc/lib
 export LD_LIBRARY_PATH

--- a/resetwpa.sh
+++ b/resetwpa.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 sudo pkill wpa_supplicant
-sudo systemctl restart dhcpcd
 sudo systemctl restart wpa_supplicant


### PR DESCRIPTION
This PR includes changes required to restart dhcpcd, in order to restore wlan connection, just after creating the p2p interface. Without these changes, the ssh connection used to start `mice.sh` gets lost immediately.

Also, I've added some minor changes to `d2.py` without which my Windows 11 laptop wouldn't succeed in connecting everytime I try. With those in place, I can now successfully connect everytime I start casting.